### PR TITLE
Leaf branch types

### DIFF
--- a/Collections/Tree.swift
+++ b/Collections/Tree.swift
@@ -119,6 +119,12 @@ extension Tree where Branch == Leaf {
 /// Value-semantic, immutable Tree structure.
 public enum Tree <Branch,Leaf> {
     
+    /// Transforms for `branch` and `leaf` cases.
+    public struct Transform <B,L> {
+        let branch: (Branch) -> B
+        let leaf: (Leaf) -> L
+    }
+    
     // MARK: - Cases
     
     /// Leaf.
@@ -171,7 +177,6 @@ public enum Tree <Branch,Leaf> {
     public var height: Int {
         
         func traverse(_ tree: Tree, height: Int) -> Int {
-            
             switch tree {
             case .leaf:
                 return height
@@ -189,7 +194,6 @@ public enum Tree <Branch,Leaf> {
     ///
     /// - throws: `TreeError` if `self` is a `leaf`.
     public func replacingTree(at index: Int, with tree: Tree) throws -> Tree {
-        
         switch self {
         case .leaf:
             throw TreeError.branchOperationPerformedOnLeaf
@@ -284,6 +288,15 @@ public enum Tree <Branch,Leaf> {
         return try traverse(self, inserting: tree, through: path, at: index)
     }
     
+    public func map <B,L> (_ transform: Transform<B,L>) -> Tree<B,L> {
+        switch self {
+        case .leaf(let value):
+            return .leaf(transform.leaf(value))
+        case .branch(let value, let trees):
+            return .branch(transform.branch(value), trees.map { $0.map(transform) })
+        }
+    }
+    
     private func insert <A> (_ element: A, into elements: [A], at index: Int) throws -> [A] {
         
         guard let (left, right) = elements.split(at: index) else {
@@ -304,7 +317,6 @@ extension Tree: CustomStringConvertible {
         }
         
         func traverse(tree: Tree, indentation: Int = 0) -> String {
-            
             switch tree {
             case .leaf(let value):
                 return indents(indentation) + "\(value)"

--- a/Collections/Tree.swift
+++ b/Collections/Tree.swift
@@ -121,8 +121,14 @@ public enum Tree <Branch,Leaf> {
     
     /// Transforms for `branch` and `leaf` cases.
     public struct Transform <B,L> {
+        
         let branch: (Branch) -> B
         let leaf: (Leaf) -> L
+        
+        public init(branch: @escaping (Branch) -> B, leaf: @escaping (Leaf) -> L) {
+            self.branch = branch
+            self.leaf = leaf
+        }
     }
     
     // MARK: - Cases

--- a/Collections/Zipper.swift
+++ b/Collections/Zipper.swift
@@ -1,42 +1,42 @@
+////
+////  Zipper.swift
+////  Collections
+////
+////  Created by James Bean on 2/5/17.
+////
+////
 //
-//  Zipper.swift
-//  Collections
-//
-//  Created by James Bean on 2/5/17.
-//
-//
-
 ///// - TODO: Nest `Crumb` inside `Zipper` inside `Tree`.
 //
 ///// Value of a `Tree` with its neighboring `Tree` values.
-//public struct Crumb <T> {
+//public struct Crumb <Leaf,Branch> {
 //    
 //    /// Associated value of the currently in-focus `tree`.
-//    public let value: T
+//    public let value: Either<Branch,Leaf>
 //    
 //    /// The other trees to the left and right of the tree currently in focus.
-//    public let trees: ([Tree<T>], [Tree<T>])
+//    public let trees: ([Tree<Leaf,Branch>], [Tree<Leaf,Branch>])
 //}
 //
 ///// Navigate an immutable n-ary `Tree` structure.
-//public struct Zipper <T> {
+//public struct Zipper <Leaf,Branch> {
 //    
 //    // MARK: - Associated Types
 //    
 //    /// Collection of `Crumb` values.
-//    public typealias Breadcrumbs = Stack<Crumb<T>>
+//    public typealias Breadcrumbs = Stack<Crumb<Leaf,Branch>>
 //    
 //    // MARK: - Instance Properties
 //    
 //    /// The `Tree` wrapped by the `Zipper`.
-//    public let tree: Tree<T>
+//    public let tree: Tree<Leaf,Branch>
 //    
 //    /// The stack of `Crumb` values that hold a history of the remaining parts of the tree
 //    /// that are not currently in focus.
 //    public let breadcrumbs: Breadcrumbs
 //    
 //    /// Move the `Zipper` up in the tree.
-//    public var up: Zipper<T>? {
+//    public var up: Zipper<Leaf,Branch>? {
 //        
 //        // If we are already at the top, our work is done.
 //        guard let (latest, remaining) = breadcrumbs.destructured else {
@@ -50,13 +50,13 @@
 //    }
 //    
 //    /// `Zipper` wrapping the `root` of the `Tree`.
-//    public var top: Zipper<T> {
+//    public var top: Zipper<Leaf,Branch> {
 //        return up?.top ?? self
 //    }
 //    
 //    /// - returns: `Zipper` values for each subtree contained by the wrapped `Tree`, if it is
 //    /// a `branch`.
-//    public var children: [Zipper<T>] {
+//    public var children: [Zipper<Leaf,Branch>] {
 //        
 //        guard case let .branch(_, trees) = tree else {
 //            return []
@@ -66,7 +66,7 @@
 //    }
 //    
 //    /// - returns: `Zipper` values for each sibling subtree of the wrapped `Tree`.
-//    public var siblings: [Zipper<T>] {
+//    public var siblings: [Zipper<Leaf,Branch>] {
 //        return up?.children ?? []
 //    }
 //
@@ -74,7 +74,7 @@
 //    
 //    /// Create a `Zipper` with a `Tree` and a history of remaining parts of the tree that
 //    /// are not currently in focus.
-//    public init(_ tree: Tree<T>, _ breadcrumbs: Breadcrumbs = Breadcrumbs()) {
+//    public init(_ tree: Tree<Leaf,Branch>, _ breadcrumbs: Breadcrumbs = Breadcrumbs()) {
 //        self.tree = tree
 //        self.breadcrumbs = breadcrumbs
 //    }
@@ -84,7 +84,7 @@
 //    /// Move focus to the sub-tree with the given `index`.
 //    ///
 //    /// - throws: `TreeError` if index is out of bounds.
-//    public func move(to index: Int) throws -> Zipper<T> {
+//    public func move(to index: Int) throws -> Zipper<Leaf,Branch> {
 //
 //        switch tree {
 //            
@@ -106,7 +106,7 @@
 //    /// Move focus to the sub-tree through the given `path`.
 //    ///
 //    /// - throws: `TreeError` if the given `path` is no good.
-//    public func move(through path: [Int]) throws -> Zipper<T> {
+//    public func move(through path: [Int]) throws -> Zipper<Leaf,Branch> {
 //        
 //        // If `path` is empty, our work is done
 //        guard let (index, remaining) = path.destructured else {

--- a/Collections/Zipper.swift
+++ b/Collections/Zipper.swift
@@ -6,129 +6,129 @@
 //
 //
 
-/// - TODO: Nest `Crumb` inside `Zipper` inside `Tree`.
-
-/// Value of a `Tree` with its neighboring `Tree` values.
-public struct Crumb <T> {
-    
-    /// Associated value of the currently in-focus `tree`.
-    public let value: T
-    
-    /// The other trees to the left and right of the tree currently in focus.
-    public let trees: ([Tree<T>], [Tree<T>])
-}
-
-/// Navigate an immutable n-ary `Tree` structure.
-public struct Zipper <T> {
-    
-    // MARK: - Associated Types
-    
-    /// Collection of `Crumb` values.
-    public typealias Breadcrumbs = Stack<Crumb<T>>
-    
-    // MARK: - Instance Properties
-    
-    /// The `Tree` wrapped by the `Zipper`.
-    public let tree: Tree<T>
-    
-    /// The stack of `Crumb` values that hold a history of the remaining parts of the tree
-    /// that are not currently in focus.
-    public let breadcrumbs: Breadcrumbs
-    
-    /// Move the `Zipper` up in the tree.
-    public var up: Zipper<T>? {
-        
-        // If we are already at the top, our work is done.
-        guard let (latest, remaining) = breadcrumbs.destructured else {
-            return nil
-        }
-        
-        let (left, right) = latest.trees
-        let trees = left + tree + right
-        
-        return Zipper(.branch(latest.value, trees), remaining)
-    }
-    
-    /// `Zipper` wrapping the `root` of the `Tree`.
-    public var top: Zipper<T> {
-        return up?.top ?? self
-    }
-    
-    /// - returns: `Zipper` values for each subtree contained by the wrapped `Tree`, if it is
-    /// a `branch`.
-    public var children: [Zipper<T>] {
-        
-        guard case let .branch(_, trees) = tree else {
-            return []
-        }
-        
-        return try! trees.indices.map(move)
-    }
-    
-    /// - returns: `Zipper` values for each sibling subtree of the wrapped `Tree`.
-    public var siblings: [Zipper<T>] {
-        return up?.children ?? []
-    }
-
-    // MARK: - Initializers
-    
-    /// Create a `Zipper` with a `Tree` and a history of remaining parts of the tree that
-    /// are not currently in focus.
-    public init(_ tree: Tree<T>, _ breadcrumbs: Breadcrumbs = Breadcrumbs()) {
-        self.tree = tree
-        self.breadcrumbs = breadcrumbs
-    }
-    
-    // MARK: - Instance Methods
-    
-    /// Move focus to the sub-tree with the given `index`.
-    ///
-    /// - throws: `TreeError` if index is out of bounds.
-    public func move(to index: Int) throws -> Zipper<T> {
-
-        switch tree {
-            
-        // Should never be called on a `leaf`
-        case .leaf:
-            throw TreeError.branchOperationPerformedOnLeaf
-            
-        case .branch(let value, let trees):
-            
-            guard let (left, subTree, right) = trees.splitAndExtractElement(at: index) else {
-                throw TreeError.illFormedIndexPath
-            }
-            
-            let crumb = Crumb(value: value, trees: (left, right))
-            return Zipper(subTree, breadcrumbs.pushing(crumb))
-        }
-    }
-    
-    /// Move focus to the sub-tree through the given `path`.
-    ///
-    /// - throws: `TreeError` if the given `path` is no good.
-    public func move(through path: [Int]) throws -> Zipper<T> {
-        
-        // If `path` is empty, our work is done
-        guard let (index, remaining) = path.destructured else {
-            return self
-        }
-        
-        return try move(to: index).move(through: remaining)
-    }
-    
-    /// Transform the value of the wrapped `Tree`.
-    public func update(_ f: (T) -> T) -> Zipper<T> {
-        
-        switch tree {
-        case .leaf(let value):
-            return Zipper(.leaf(f(value)), breadcrumbs)
-        case .branch(let value, let trees):
-            return Zipper(.branch(f(value), trees), breadcrumbs)
-        }
-    }
-    
-    /// Replace the value of the wrapped `Tree` with the given `value`.
-    public func update(value: T) -> Zipper<T> {
-        return update { _ in value }
-    }
-}
+///// - TODO: Nest `Crumb` inside `Zipper` inside `Tree`.
+//
+///// Value of a `Tree` with its neighboring `Tree` values.
+//public struct Crumb <T> {
+//    
+//    /// Associated value of the currently in-focus `tree`.
+//    public let value: T
+//    
+//    /// The other trees to the left and right of the tree currently in focus.
+//    public let trees: ([Tree<T>], [Tree<T>])
+//}
+//
+///// Navigate an immutable n-ary `Tree` structure.
+//public struct Zipper <T> {
+//    
+//    // MARK: - Associated Types
+//    
+//    /// Collection of `Crumb` values.
+//    public typealias Breadcrumbs = Stack<Crumb<T>>
+//    
+//    // MARK: - Instance Properties
+//    
+//    /// The `Tree` wrapped by the `Zipper`.
+//    public let tree: Tree<T>
+//    
+//    /// The stack of `Crumb` values that hold a history of the remaining parts of the tree
+//    /// that are not currently in focus.
+//    public let breadcrumbs: Breadcrumbs
+//    
+//    /// Move the `Zipper` up in the tree.
+//    public var up: Zipper<T>? {
+//        
+//        // If we are already at the top, our work is done.
+//        guard let (latest, remaining) = breadcrumbs.destructured else {
+//            return nil
+//        }
+//        
+//        let (left, right) = latest.trees
+//        let trees = left + tree + right
+//        
+//        return Zipper(.branch(latest.value, trees), remaining)
+//    }
+//    
+//    /// `Zipper` wrapping the `root` of the `Tree`.
+//    public var top: Zipper<T> {
+//        return up?.top ?? self
+//    }
+//    
+//    /// - returns: `Zipper` values for each subtree contained by the wrapped `Tree`, if it is
+//    /// a `branch`.
+//    public var children: [Zipper<T>] {
+//        
+//        guard case let .branch(_, trees) = tree else {
+//            return []
+//        }
+//        
+//        return try! trees.indices.map(move)
+//    }
+//    
+//    /// - returns: `Zipper` values for each sibling subtree of the wrapped `Tree`.
+//    public var siblings: [Zipper<T>] {
+//        return up?.children ?? []
+//    }
+//
+//    // MARK: - Initializers
+//    
+//    /// Create a `Zipper` with a `Tree` and a history of remaining parts of the tree that
+//    /// are not currently in focus.
+//    public init(_ tree: Tree<T>, _ breadcrumbs: Breadcrumbs = Breadcrumbs()) {
+//        self.tree = tree
+//        self.breadcrumbs = breadcrumbs
+//    }
+//    
+//    // MARK: - Instance Methods
+//    
+//    /// Move focus to the sub-tree with the given `index`.
+//    ///
+//    /// - throws: `TreeError` if index is out of bounds.
+//    public func move(to index: Int) throws -> Zipper<T> {
+//
+//        switch tree {
+//            
+//        // Should never be called on a `leaf`
+//        case .leaf:
+//            throw TreeError.branchOperationPerformedOnLeaf
+//            
+//        case .branch(let value, let trees):
+//            
+//            guard let (left, subTree, right) = trees.splitAndExtractElement(at: index) else {
+//                throw TreeError.illFormedIndexPath
+//            }
+//            
+//            let crumb = Crumb(value: value, trees: (left, right))
+//            return Zipper(subTree, breadcrumbs.pushing(crumb))
+//        }
+//    }
+//    
+//    /// Move focus to the sub-tree through the given `path`.
+//    ///
+//    /// - throws: `TreeError` if the given `path` is no good.
+//    public func move(through path: [Int]) throws -> Zipper<T> {
+//        
+//        // If `path` is empty, our work is done
+//        guard let (index, remaining) = path.destructured else {
+//            return self
+//        }
+//        
+//        return try move(to: index).move(through: remaining)
+//    }
+//    
+//    /// Transform the value of the wrapped `Tree`.
+//    public func update(_ f: (T) -> T) -> Zipper<T> {
+//        
+//        switch tree {
+//        case .leaf(let value):
+//            return Zipper(.leaf(f(value)), breadcrumbs)
+//        case .branch(let value, let trees):
+//            return Zipper(.branch(f(value), trees), breadcrumbs)
+//        }
+//    }
+//    
+//    /// Replace the value of the wrapped `Tree` with the given `value`.
+//    public func update(value: T) -> Zipper<T> {
+//        return update { _ in value }
+//    }
+//}

--- a/CollectionsTests/TreeTests.swift
+++ b/CollectionsTests/TreeTests.swift
@@ -9,346 +9,346 @@
 import XCTest
 import Collections
 
-class TreeNodeTests: XCTestCase {
-    
-    private var tree: Tree<Int> {
-        return Tree.branch(0, [
-            .leaf(1),
-            .leaf(2),
-            .leaf(3)
-        ])
-    }
-    
-    func testLeafInit() {
-        let _ = Tree<Int>.leaf(1)
-    }
-    
-    func testInitWithSequence() {
-        
-        let seq = [1,2,3,4,5]
-        let branch = Tree(0, seq)
-        
-        guard case .branch = branch else {
-            XCTFail()
-            return
-        }
-    }
-    
-    func testUpdatingValueLeaf() {
-        let leaf = Tree.leaf(1)
-        XCTAssertEqual(leaf.updating(value: 4).value, 4)
-    }
-    
-    func testUpdateValueBranch() {
-        let branch = Tree.branch(1, [.leaf(1), .leaf(2), .leaf(3)])
-        XCTAssertEqual(branch.updating(value: 4).value, 4)
-    }
-    
-    func testLeavesLeaf() {
-        let leaf: Tree<Int> = .leaf(1)
-        XCTAssertEqual(leaf.leaves, [1])
-    }
-    
-    func testLeavesBranchSingleChild() {
-        let container: Tree = .branch(0, [.leaf(1)])
-        XCTAssertEqual(container.leaves, [1])
-    }
-    
-    func testLeavesBranchMultipleTrees() {
-        let container = Tree.branch(0, [.leaf(1), .leaf(2), .leaf(3)])
-        XCTAssertEqual(container.leaves, [1,2,3])
-    }
-    
-    func testLeavesMultipleDepth() {
-        
-        let container = Tree.branch(0, [
-            .leaf(1),
-            .branch(0, [
-                .leaf(2),
-                .leaf(3),
-                .leaf(4)
-            ]),
-            .leaf(5),
-            .branch(0, [
-                .leaf(6),
-                .branch(0, [
-                    .leaf(7),
-                    .leaf(8)
-                ])
-            ])
-        ])
-        
-        XCTAssertEqual(container.leaves, [1,2,3,4,5,6,7,8])
-    }
-    
-    func testReplacingLeafAtBegining() {
-        
-        let newTree = try! tree.replacingTree(at: 0, with: .leaf(0))
-        XCTAssertEqual(newTree.leaves, [0,2,3])
-    }
-    
-    func testReplacingLeafInMiddle() {
-        
-        let newTree = try! tree.replacingTree(at: 1, with: .leaf(0))
-        XCTAssertEqual(newTree.leaves, [1,0,3])
-    }
-    
-    func testReplacingLeafAtEnd() {
-        
-        let newTree = try! tree.replacingTree(at: 2, with: .leaf(0))
-        XCTAssertEqual(newTree.leaves, [1,2,0])
-    }
-    
-    func testReplaceLeafAtPath() {
-        
-        let newTree = try! tree.replacingTree(through: [1], with: .leaf(0))
-        XCTAssertEqual(newTree.leaves, [1,0,3])
-    }
-    
-    func testReplaceAtPathNested() {
-        
-        let tree = Tree.branch(-1, [
-            .leaf(0),
-            .branch(-1, [
-                .leaf(1),
-                .leaf(2),
-                .leaf(3)
-            ])
-        ])
-        
-        let newTree = try! tree.replacingTree(through: [1,2], with: .leaf(4))
-        XCTAssertEqual(newTree.leaves, [0,1,2,4])
-    }
-    
-    func testInsertLeafAtBeginningSingleDepth() {
-        
-        let leafToInsert = Tree.leaf(0)
-        let newTree = try! tree.inserting(leafToInsert, at: 0)
-        XCTAssertEqual(newTree.leaves, [0,1,2,3])
-    }
-    
-    func testInsertBranchAtBeginningSingleDepth() {
-        
-        let treeToInsert = Tree.branch(0, [
-            .leaf(-1),
-            .leaf(0)
-        ])
-        
-        let newTree = try! tree.inserting(treeToInsert, at: 0)
-        XCTAssertEqual(newTree.leaves, [-1,0,1,2,3])
-    }
-    
-    func testInsertBranchInMiddleSingleDepth() {
-        
-        let treeToInsert = Tree.branch(0, [
-            .leaf(0),
-            .leaf(0)
-        ])
-        
-        let newTree = try! tree.inserting(treeToInsert, at: 1)
-        XCTAssertEqual(newTree.leaves, [1,0,0,2,3])
-    }
-    
-    func testInsertBranchAtEndSingleDepth() {
-        
-        let treeToInsert = Tree.branch(0, [
-            .leaf(4),
-            .leaf(5)
-        ])
-        
-        let newTree = try! tree.inserting(treeToInsert, at: 3)
-        XCTAssertEqual(newTree.leaves, [1,2,3,4,5])
-    }
-    
-    func testInsertLeafNested() {
-        
-        //         -1
-        //        / | \
-        //      -1 -1  4
-        //         /|\
-        //        1 2(3) insert
-        let tree = Tree.branch(-1, [
-            .leaf(0),
-            .branch(-1, [
-                .leaf(1),
-                .leaf(2)
-            ])
-        ])
-        
-        let newTree = try! tree.inserting(.leaf(3), through: [], at: 2)
-        XCTAssertEqual(newTree.leaves, [0,1,2,3])
-    }
-    
-    func testInsertLeafNestedLessNested() {
-        
-        //         -1
-        //        / | \
-        //      -1 -1  4
-        //         /|\
-        //        1 2(3) insert
-        let tree = Tree.branch(-1, [
-            .leaf(0),
-            .branch(-1, [
-                .leaf(1),
-                .leaf(2)
-            ]),
-            .leaf(3)
-        ])
-        
-        let newTree = try! tree.inserting(.leaf(4), through: [], at: 3)
-        XCTAssertEqual(newTree.leaves, [0,1,2,3,4])
-    }
-    
-    func testInsertBranchReallyNested() {
-        
-        let tree = Tree.branch(-1, [
-            .branch(-1, [
-                .leaf(0),
-                .leaf(1)
-            ]),
-            .branch(-1, [
-                .leaf(2),
-                .branch(-1, [
-                    .leaf(3),
-                    .branch(-1, [
-                        .leaf(4),
-                        
-                        // insert branch here!
-                        
-                        .leaf(10)
-                    ]),
-                    .leaf(11)
-                ]),
-                .leaf(12)
-            ])
-        ])
-        
-        let branchToInsert = Tree.branch(-1, [
-            .leaf(5),
-            .leaf(6),
-            .branch(-1, [
-                .leaf(7),
-                .leaf(8),
-                .leaf(9)
-            ])
-        ])
-        
-        let newTree = try! tree.inserting(branchToInsert, through: [1,1,1], at: 1)
-        XCTAssertEqual(newTree.leaves, [0,1,2,3,4,5,6,7,8,9,10,11,12])
-    }
-    
-    func testMap() {
-        
-        let tree = Tree.branch(1, [
-            .leaf(2),
-            .branch(3, [
-                .leaf(4),
-                .leaf(5)
-            ]),
-            .leaf(6)
-        ])
-        
-        let expected = Tree.branch(2, [
-            .leaf(4),
-            .branch(6, [
-                .leaf(8),
-                .leaf(10)
-            ]),
-            .leaf(12)
-        ])
-        
-        XCTAssert(tree.map { $0 * 2 } == expected)
-    }
-    
-    func testHeightLeafZero() {
-        XCTAssertEqual(Tree.leaf(0).height, 0)
-    }
-    
-    func testHeightBranchSingleDepthOne() {
-        
-        let branch = Tree.branch(-1, [
-            .leaf(1),
-            .leaf(1)
-        ])
-        
-        XCTAssertEqual(branch.height, 1)
-    }
-    
-    func testHeightNested() {
-        
-        let branch = Tree.branch(-1, [
-            .leaf(1),
-            .branch(1, [
-                .leaf(1),
-                .branch(1, [
-                    .leaf(1),
-                    .leaf(1)
-                ])
-            ])
-        ])
-        
-        XCTAssertEqual(branch.height, 3)
-    }
-    
-    func testPath() {
-        
-        let tree = Tree.branch(1, [
-            .leaf(1),
-            .branch(2, [
-                .leaf(3),
-                .leaf(4)
-            ]),
-            .leaf(5)
-        ])
-        
-        let expected = [[1,1],[1,2,3],[1,2,4],[1,5]]
-        
-        zip(tree.paths, expected).forEach { path, expected in
-            XCTAssertEqual(path, expected)
-        }
-    }
-    
-    func testPathLeaf() {
-        XCTAssertEqual(Tree.leaf(1).paths.count, 1)
-        XCTAssertEqual(Tree.leaf(1).paths[0][0], 1)
-    }
-    
-    func testTreeZip() {
-        
-        let a = Tree.branch(1, [
-            .leaf(2),
-            .leaf(3),
-            .branch(4, [
-                .leaf(5),
-                .leaf(6)
-                ])
-            ])
-        
-        let b = Tree.branch(0, [
-            .leaf(1),
-            .leaf(2),
-            .branch(3, [
-                .leaf(4),
-                .leaf(5)
-                ])
-            ])
-        
-        let expected = Tree.branch(0, [
-            .leaf(2),
-            .leaf(6),
-            .branch(12, [
-                .leaf(20),
-                .leaf(30)
-                ])
-            ])
-        
-        let result = zip(a,b,*)
-        XCTAssert(result == expected)
-    }
-    
-    func testInitWithValueAndEmptyArray() {
-        let tree = Tree(1, [])
-        let expected = Tree.branch(1, [.leaf(1)])
-        XCTAssert(tree == expected)
-    }
-}
+//class TreeNodeTests: XCTestCase {
+//    
+//    private var tree: Tree<Int> {
+//        return Tree.branch(0, [
+//            .leaf(1),
+//            .leaf(2),
+//            .leaf(3)
+//        ])
+//    }
+//    
+//    func testLeafInit() {
+//        let _ = Tree<Int>.leaf(1)
+//    }
+//    
+//    func testInitWithSequence() {
+//        
+//        let seq = [1,2,3,4,5]
+//        let branch = Tree(0, seq)
+//        
+//        guard case .branch = branch else {
+//            XCTFail()
+//            return
+//        }
+//    }
+//    
+//    func testUpdatingValueLeaf() {
+//        let leaf = Tree.leaf(1)
+//        XCTAssertEqual(leaf.updating(value: 4).value, 4)
+//    }
+//    
+//    func testUpdateValueBranch() {
+//        let branch = Tree.branch(1, [.leaf(1), .leaf(2), .leaf(3)])
+//        XCTAssertEqual(branch.updating(value: 4).value, 4)
+//    }
+//    
+//    func testLeavesLeaf() {
+//        let leaf: Tree<Int> = .leaf(1)
+//        XCTAssertEqual(leaf.leaves, [1])
+//    }
+//    
+//    func testLeavesBranchSingleChild() {
+//        let container: Tree = .branch(0, [.leaf(1)])
+//        XCTAssertEqual(container.leaves, [1])
+//    }
+//    
+//    func testLeavesBranchMultipleTrees() {
+//        let container = Tree.branch(0, [.leaf(1), .leaf(2), .leaf(3)])
+//        XCTAssertEqual(container.leaves, [1,2,3])
+//    }
+//    
+//    func testLeavesMultipleDepth() {
+//        
+//        let container = Tree.branch(0, [
+//            .leaf(1),
+//            .branch(0, [
+//                .leaf(2),
+//                .leaf(3),
+//                .leaf(4)
+//            ]),
+//            .leaf(5),
+//            .branch(0, [
+//                .leaf(6),
+//                .branch(0, [
+//                    .leaf(7),
+//                    .leaf(8)
+//                ])
+//            ])
+//        ])
+//        
+//        XCTAssertEqual(container.leaves, [1,2,3,4,5,6,7,8])
+//    }
+//    
+//    func testReplacingLeafAtBegining() {
+//        
+//        let newTree = try! tree.replacingTree(at: 0, with: .leaf(0))
+//        XCTAssertEqual(newTree.leaves, [0,2,3])
+//    }
+//    
+//    func testReplacingLeafInMiddle() {
+//        
+//        let newTree = try! tree.replacingTree(at: 1, with: .leaf(0))
+//        XCTAssertEqual(newTree.leaves, [1,0,3])
+//    }
+//    
+//    func testReplacingLeafAtEnd() {
+//        
+//        let newTree = try! tree.replacingTree(at: 2, with: .leaf(0))
+//        XCTAssertEqual(newTree.leaves, [1,2,0])
+//    }
+//    
+//    func testReplaceLeafAtPath() {
+//        
+//        let newTree = try! tree.replacingTree(through: [1], with: .leaf(0))
+//        XCTAssertEqual(newTree.leaves, [1,0,3])
+//    }
+//    
+//    func testReplaceAtPathNested() {
+//        
+//        let tree = Tree.branch(-1, [
+//            .leaf(0),
+//            .branch(-1, [
+//                .leaf(1),
+//                .leaf(2),
+//                .leaf(3)
+//            ])
+//        ])
+//        
+//        let newTree = try! tree.replacingTree(through: [1,2], with: .leaf(4))
+//        XCTAssertEqual(newTree.leaves, [0,1,2,4])
+//    }
+//    
+//    func testInsertLeafAtBeginningSingleDepth() {
+//        
+//        let leafToInsert = Tree.leaf(0)
+//        let newTree = try! tree.inserting(leafToInsert, at: 0)
+//        XCTAssertEqual(newTree.leaves, [0,1,2,3])
+//    }
+//    
+//    func testInsertBranchAtBeginningSingleDepth() {
+//        
+//        let treeToInsert = Tree.branch(0, [
+//            .leaf(-1),
+//            .leaf(0)
+//        ])
+//        
+//        let newTree = try! tree.inserting(treeToInsert, at: 0)
+//        XCTAssertEqual(newTree.leaves, [-1,0,1,2,3])
+//    }
+//    
+//    func testInsertBranchInMiddleSingleDepth() {
+//        
+//        let treeToInsert = Tree.branch(0, [
+//            .leaf(0),
+//            .leaf(0)
+//        ])
+//        
+//        let newTree = try! tree.inserting(treeToInsert, at: 1)
+//        XCTAssertEqual(newTree.leaves, [1,0,0,2,3])
+//    }
+//    
+//    func testInsertBranchAtEndSingleDepth() {
+//        
+//        let treeToInsert = Tree.branch(0, [
+//            .leaf(4),
+//            .leaf(5)
+//        ])
+//        
+//        let newTree = try! tree.inserting(treeToInsert, at: 3)
+//        XCTAssertEqual(newTree.leaves, [1,2,3,4,5])
+//    }
+//    
+//    func testInsertLeafNested() {
+//        
+//        //         -1
+//        //        / | \
+//        //      -1 -1  4
+//        //         /|\
+//        //        1 2(3) insert
+//        let tree = Tree.branch(-1, [
+//            .leaf(0),
+//            .branch(-1, [
+//                .leaf(1),
+//                .leaf(2)
+//            ])
+//        ])
+//        
+//        let newTree = try! tree.inserting(.leaf(3), through: [], at: 2)
+//        XCTAssertEqual(newTree.leaves, [0,1,2,3])
+//    }
+//    
+//    func testInsertLeafNestedLessNested() {
+//        
+//        //         -1
+//        //        / | \
+//        //      -1 -1  4
+//        //         /|\
+//        //        1 2(3) insert
+//        let tree = Tree.branch(-1, [
+//            .leaf(0),
+//            .branch(-1, [
+//                .leaf(1),
+//                .leaf(2)
+//            ]),
+//            .leaf(3)
+//        ])
+//        
+//        let newTree = try! tree.inserting(.leaf(4), through: [], at: 3)
+//        XCTAssertEqual(newTree.leaves, [0,1,2,3,4])
+//    }
+//    
+//    func testInsertBranchReallyNested() {
+//        
+//        let tree = Tree.branch(-1, [
+//            .branch(-1, [
+//                .leaf(0),
+//                .leaf(1)
+//            ]),
+//            .branch(-1, [
+//                .leaf(2),
+//                .branch(-1, [
+//                    .leaf(3),
+//                    .branch(-1, [
+//                        .leaf(4),
+//                        
+//                        // insert branch here!
+//                        
+//                        .leaf(10)
+//                    ]),
+//                    .leaf(11)
+//                ]),
+//                .leaf(12)
+//            ])
+//        ])
+//        
+//        let branchToInsert = Tree.branch(-1, [
+//            .leaf(5),
+//            .leaf(6),
+//            .branch(-1, [
+//                .leaf(7),
+//                .leaf(8),
+//                .leaf(9)
+//            ])
+//        ])
+//        
+//        let newTree = try! tree.inserting(branchToInsert, through: [1,1,1], at: 1)
+//        XCTAssertEqual(newTree.leaves, [0,1,2,3,4,5,6,7,8,9,10,11,12])
+//    }
+//    
+//    func testMap() {
+//        
+//        let tree = Tree.branch(1, [
+//            .leaf(2),
+//            .branch(3, [
+//                .leaf(4),
+//                .leaf(5)
+//            ]),
+//            .leaf(6)
+//        ])
+//        
+//        let expected = Tree.branch(2, [
+//            .leaf(4),
+//            .branch(6, [
+//                .leaf(8),
+//                .leaf(10)
+//            ]),
+//            .leaf(12)
+//        ])
+//        
+//        XCTAssert(tree.map { $0 * 2 } == expected)
+//    }
+//    
+//    func testHeightLeafZero() {
+//        XCTAssertEqual(Tree.leaf(0).height, 0)
+//    }
+//    
+//    func testHeightBranchSingleDepthOne() {
+//        
+//        let branch = Tree.branch(-1, [
+//            .leaf(1),
+//            .leaf(1)
+//        ])
+//        
+//        XCTAssertEqual(branch.height, 1)
+//    }
+//    
+//    func testHeightNested() {
+//        
+//        let branch = Tree.branch(-1, [
+//            .leaf(1),
+//            .branch(1, [
+//                .leaf(1),
+//                .branch(1, [
+//                    .leaf(1),
+//                    .leaf(1)
+//                ])
+//            ])
+//        ])
+//        
+//        XCTAssertEqual(branch.height, 3)
+//    }
+//    
+//    func testPath() {
+//        
+//        let tree = Tree.branch(1, [
+//            .leaf(1),
+//            .branch(2, [
+//                .leaf(3),
+//                .leaf(4)
+//            ]),
+//            .leaf(5)
+//        ])
+//        
+//        let expected = [[1,1],[1,2,3],[1,2,4],[1,5]]
+//        
+//        zip(tree.paths, expected).forEach { path, expected in
+//            XCTAssertEqual(path, expected)
+//        }
+//    }
+//    
+//    func testPathLeaf() {
+//        XCTAssertEqual(Tree.leaf(1).paths.count, 1)
+//        XCTAssertEqual(Tree.leaf(1).paths[0][0], 1)
+//    }
+//    
+//    func testTreeZip() {
+//        
+//        let a = Tree.branch(1, [
+//            .leaf(2),
+//            .leaf(3),
+//            .branch(4, [
+//                .leaf(5),
+//                .leaf(6)
+//                ])
+//            ])
+//        
+//        let b = Tree.branch(0, [
+//            .leaf(1),
+//            .leaf(2),
+//            .branch(3, [
+//                .leaf(4),
+//                .leaf(5)
+//                ])
+//            ])
+//        
+//        let expected = Tree.branch(0, [
+//            .leaf(2),
+//            .leaf(6),
+//            .branch(12, [
+//                .leaf(20),
+//                .leaf(30)
+//                ])
+//            ])
+//        
+//        let result = zip(a,b,*)
+//        XCTAssert(result == expected)
+//    }
+//    
+//    func testInitWithValueAndEmptyArray() {
+//        let tree = Tree(1, [])
+//        let expected = Tree.branch(1, [.leaf(1)])
+//        XCTAssert(tree == expected)
+//    }
+//}

--- a/CollectionsTests/TreeTests.swift
+++ b/CollectionsTests/TreeTests.swift
@@ -9,346 +9,351 @@
 import XCTest
 import Collections
 
-//class TreeNodeTests: XCTestCase {
-//    
-//    private var tree: Tree<Int> {
-//        return Tree.branch(0, [
-//            .leaf(1),
-//            .leaf(2),
-//            .leaf(3)
-//        ])
-//    }
-//    
-//    func testLeafInit() {
-//        let _ = Tree<Int>.leaf(1)
-//    }
-//    
-//    func testInitWithSequence() {
-//        
-//        let seq = [1,2,3,4,5]
-//        let branch = Tree(0, seq)
-//        
-//        guard case .branch = branch else {
-//            XCTFail()
-//            return
-//        }
-//    }
-//    
-//    func testUpdatingValueLeaf() {
-//        let leaf = Tree.leaf(1)
-//        XCTAssertEqual(leaf.updating(value: 4).value, 4)
-//    }
-//    
-//    func testUpdateValueBranch() {
-//        let branch = Tree.branch(1, [.leaf(1), .leaf(2), .leaf(3)])
-//        XCTAssertEqual(branch.updating(value: 4).value, 4)
-//    }
-//    
-//    func testLeavesLeaf() {
-//        let leaf: Tree<Int> = .leaf(1)
-//        XCTAssertEqual(leaf.leaves, [1])
-//    }
-//    
-//    func testLeavesBranchSingleChild() {
-//        let container: Tree = .branch(0, [.leaf(1)])
-//        XCTAssertEqual(container.leaves, [1])
-//    }
-//    
-//    func testLeavesBranchMultipleTrees() {
-//        let container = Tree.branch(0, [.leaf(1), .leaf(2), .leaf(3)])
-//        XCTAssertEqual(container.leaves, [1,2,3])
-//    }
-//    
-//    func testLeavesMultipleDepth() {
-//        
-//        let container = Tree.branch(0, [
-//            .leaf(1),
-//            .branch(0, [
-//                .leaf(2),
-//                .leaf(3),
-//                .leaf(4)
-//            ]),
-//            .leaf(5),
-//            .branch(0, [
-//                .leaf(6),
-//                .branch(0, [
-//                    .leaf(7),
-//                    .leaf(8)
-//                ])
-//            ])
-//        ])
-//        
-//        XCTAssertEqual(container.leaves, [1,2,3,4,5,6,7,8])
-//    }
-//    
-//    func testReplacingLeafAtBegining() {
-//        
-//        let newTree = try! tree.replacingTree(at: 0, with: .leaf(0))
-//        XCTAssertEqual(newTree.leaves, [0,2,3])
-//    }
-//    
-//    func testReplacingLeafInMiddle() {
-//        
-//        let newTree = try! tree.replacingTree(at: 1, with: .leaf(0))
-//        XCTAssertEqual(newTree.leaves, [1,0,3])
-//    }
-//    
-//    func testReplacingLeafAtEnd() {
-//        
-//        let newTree = try! tree.replacingTree(at: 2, with: .leaf(0))
-//        XCTAssertEqual(newTree.leaves, [1,2,0])
-//    }
-//    
-//    func testReplaceLeafAtPath() {
-//        
-//        let newTree = try! tree.replacingTree(through: [1], with: .leaf(0))
-//        XCTAssertEqual(newTree.leaves, [1,0,3])
-//    }
-//    
-//    func testReplaceAtPathNested() {
-//        
-//        let tree = Tree.branch(-1, [
-//            .leaf(0),
-//            .branch(-1, [
-//                .leaf(1),
-//                .leaf(2),
-//                .leaf(3)
-//            ])
-//        ])
-//        
-//        let newTree = try! tree.replacingTree(through: [1,2], with: .leaf(4))
-//        XCTAssertEqual(newTree.leaves, [0,1,2,4])
-//    }
-//    
-//    func testInsertLeafAtBeginningSingleDepth() {
-//        
-//        let leafToInsert = Tree.leaf(0)
-//        let newTree = try! tree.inserting(leafToInsert, at: 0)
-//        XCTAssertEqual(newTree.leaves, [0,1,2,3])
-//    }
-//    
-//    func testInsertBranchAtBeginningSingleDepth() {
-//        
-//        let treeToInsert = Tree.branch(0, [
-//            .leaf(-1),
-//            .leaf(0)
-//        ])
-//        
-//        let newTree = try! tree.inserting(treeToInsert, at: 0)
-//        XCTAssertEqual(newTree.leaves, [-1,0,1,2,3])
-//    }
-//    
-//    func testInsertBranchInMiddleSingleDepth() {
-//        
-//        let treeToInsert = Tree.branch(0, [
-//            .leaf(0),
-//            .leaf(0)
-//        ])
-//        
-//        let newTree = try! tree.inserting(treeToInsert, at: 1)
-//        XCTAssertEqual(newTree.leaves, [1,0,0,2,3])
-//    }
-//    
-//    func testInsertBranchAtEndSingleDepth() {
-//        
-//        let treeToInsert = Tree.branch(0, [
-//            .leaf(4),
-//            .leaf(5)
-//        ])
-//        
-//        let newTree = try! tree.inserting(treeToInsert, at: 3)
-//        XCTAssertEqual(newTree.leaves, [1,2,3,4,5])
-//    }
-//    
-//    func testInsertLeafNested() {
-//        
-//        //         -1
-//        //        / | \
-//        //      -1 -1  4
-//        //         /|\
-//        //        1 2(3) insert
-//        let tree = Tree.branch(-1, [
-//            .leaf(0),
-//            .branch(-1, [
-//                .leaf(1),
-//                .leaf(2)
-//            ])
-//        ])
-//        
-//        let newTree = try! tree.inserting(.leaf(3), through: [], at: 2)
-//        XCTAssertEqual(newTree.leaves, [0,1,2,3])
-//    }
-//    
-//    func testInsertLeafNestedLessNested() {
-//        
-//        //         -1
-//        //        / | \
-//        //      -1 -1  4
-//        //         /|\
-//        //        1 2(3) insert
-//        let tree = Tree.branch(-1, [
-//            .leaf(0),
-//            .branch(-1, [
-//                .leaf(1),
-//                .leaf(2)
-//            ]),
-//            .leaf(3)
-//        ])
-//        
-//        let newTree = try! tree.inserting(.leaf(4), through: [], at: 3)
-//        XCTAssertEqual(newTree.leaves, [0,1,2,3,4])
-//    }
-//    
-//    func testInsertBranchReallyNested() {
-//        
-//        let tree = Tree.branch(-1, [
-//            .branch(-1, [
-//                .leaf(0),
-//                .leaf(1)
-//            ]),
-//            .branch(-1, [
-//                .leaf(2),
-//                .branch(-1, [
-//                    .leaf(3),
-//                    .branch(-1, [
-//                        .leaf(4),
-//                        
-//                        // insert branch here!
-//                        
-//                        .leaf(10)
-//                    ]),
-//                    .leaf(11)
-//                ]),
-//                .leaf(12)
-//            ])
-//        ])
-//        
-//        let branchToInsert = Tree.branch(-1, [
-//            .leaf(5),
-//            .leaf(6),
-//            .branch(-1, [
-//                .leaf(7),
-//                .leaf(8),
-//                .leaf(9)
-//            ])
-//        ])
-//        
-//        let newTree = try! tree.inserting(branchToInsert, through: [1,1,1], at: 1)
-//        XCTAssertEqual(newTree.leaves, [0,1,2,3,4,5,6,7,8,9,10,11,12])
-//    }
-//    
-//    func testMap() {
-//        
-//        let tree = Tree.branch(1, [
-//            .leaf(2),
-//            .branch(3, [
-//                .leaf(4),
-//                .leaf(5)
-//            ]),
-//            .leaf(6)
-//        ])
-//        
-//        let expected = Tree.branch(2, [
-//            .leaf(4),
-//            .branch(6, [
-//                .leaf(8),
-//                .leaf(10)
-//            ]),
-//            .leaf(12)
-//        ])
-//        
-//        XCTAssert(tree.map { $0 * 2 } == expected)
-//    }
-//    
-//    func testHeightLeafZero() {
-//        XCTAssertEqual(Tree.leaf(0).height, 0)
-//    }
-//    
-//    func testHeightBranchSingleDepthOne() {
-//        
-//        let branch = Tree.branch(-1, [
-//            .leaf(1),
-//            .leaf(1)
-//        ])
-//        
-//        XCTAssertEqual(branch.height, 1)
-//    }
-//    
-//    func testHeightNested() {
-//        
-//        let branch = Tree.branch(-1, [
-//            .leaf(1),
-//            .branch(1, [
-//                .leaf(1),
-//                .branch(1, [
-//                    .leaf(1),
-//                    .leaf(1)
-//                ])
-//            ])
-//        ])
-//        
-//        XCTAssertEqual(branch.height, 3)
-//    }
-//    
-//    func testPath() {
-//        
-//        let tree = Tree.branch(1, [
-//            .leaf(1),
-//            .branch(2, [
-//                .leaf(3),
-//                .leaf(4)
-//            ]),
-//            .leaf(5)
-//        ])
-//        
-//        let expected = [[1,1],[1,2,3],[1,2,4],[1,5]]
-//        
-//        zip(tree.paths, expected).forEach { path, expected in
-//            XCTAssertEqual(path, expected)
-//        }
-//    }
-//    
-//    func testPathLeaf() {
-//        XCTAssertEqual(Tree.leaf(1).paths.count, 1)
-//        XCTAssertEqual(Tree.leaf(1).paths[0][0], 1)
-//    }
-//    
-//    func testTreeZip() {
-//        
-//        let a = Tree.branch(1, [
-//            .leaf(2),
-//            .leaf(3),
-//            .branch(4, [
-//                .leaf(5),
-//                .leaf(6)
-//                ])
-//            ])
-//        
-//        let b = Tree.branch(0, [
-//            .leaf(1),
-//            .leaf(2),
-//            .branch(3, [
-//                .leaf(4),
-//                .leaf(5)
-//                ])
-//            ])
-//        
-//        let expected = Tree.branch(0, [
-//            .leaf(2),
-//            .leaf(6),
-//            .branch(12, [
-//                .leaf(20),
-//                .leaf(30)
-//                ])
-//            ])
-//        
-//        let result = zip(a,b,*)
-//        XCTAssert(result == expected)
-//    }
-//    
-//    func testInitWithValueAndEmptyArray() {
-//        let tree = Tree(1, [])
-//        let expected = Tree.branch(1, [.leaf(1)])
-//        XCTAssert(tree == expected)
-//    }
-//}
+class TreeNodeTests: XCTestCase {
+    
+    private var tree: Tree<Int,Int> {
+        return Tree.branch(0, [
+            .leaf(1),
+            .leaf(2),
+            .leaf(3)
+        ])
+    }
+    
+    func testLeafInit() {
+        let _ = Tree<Int,Int>.leaf(1)
+    }
+    
+    func testInitWithSequence() {
+        
+        let seq = [1,2,3,4,5]
+        let branch = Tree(0, seq)
+        
+        guard case .branch = branch else {
+            XCTFail()
+            return
+        }
+    }
+    
+    func testUpdatingValueLeaf() {
+        let leaf = Tree<Int,Int>.leaf(1)
+        XCTAssertEqual(leaf.updating(value: 4).value, 4)
+    }
+    
+    func testUpdateValueBranch() {
+        let branch = Tree.branch(1, [.leaf(1), .leaf(2), .leaf(3)])
+        XCTAssertEqual(branch.updating(value: 4).value, 4)
+    }
+    
+    func testLeavesLeaf() {
+        let leaf: Tree<Int,Int> = .leaf(1)
+        XCTAssertEqual(leaf.leaves, [1])
+    }
+    
+    func testLeavesBranchSingleChild() {
+        let container: Tree = .branch(0, [.leaf(1)])
+        XCTAssertEqual(container.leaves, [1])
+    }
+    
+    func testLeavesBranchMultipleTrees() {
+        let container = Tree.branch(0, [.leaf(1), .leaf(2), .leaf(3)])
+        XCTAssertEqual(container.leaves, [1,2,3])
+    }
+    
+    func testLeavesMultipleDepth() {
+        
+        let container = Tree.branch(0, [
+            .leaf(1),
+            .branch(0, [
+                .leaf(2),
+                .leaf(3),
+                .leaf(4)
+            ]),
+            .leaf(5),
+            .branch(0, [
+                .leaf(6),
+                .branch(0, [
+                    .leaf(7),
+                    .leaf(8)
+                ])
+            ])
+        ])
+        
+        XCTAssertEqual(container.leaves, [1,2,3,4,5,6,7,8])
+    }
+    
+    func testReplacingLeafAtBegining() {
+        
+        let newTree = try! tree.replacingTree(at: 0, with: .leaf(0))
+        XCTAssertEqual(newTree.leaves, [0,2,3])
+    }
+    
+    func testReplacingLeafInMiddle() {
+        
+        let newTree = try! tree.replacingTree(at: 1, with: .leaf(0))
+        XCTAssertEqual(newTree.leaves, [1,0,3])
+    }
+    
+    func testReplacingLeafAtEnd() {
+        
+        let newTree = try! tree.replacingTree(at: 2, with: .leaf(0))
+        XCTAssertEqual(newTree.leaves, [1,2,0])
+    }
+    
+    func testReplaceLeafAtPath() {
+        
+        let newTree = try! tree.replacingTree(through: [1], with: .leaf(0))
+        XCTAssertEqual(newTree.leaves, [1,0,3])
+    }
+    
+    func testReplaceAtPathNested() {
+        
+        let tree = Tree.branch(-1, [
+            .leaf(0),
+            .branch(-1, [
+                .leaf(1),
+                .leaf(2),
+                .leaf(3)
+            ])
+        ])
+        
+        let newTree = try! tree.replacingTree(through: [1,2], with: .leaf(4))
+        XCTAssertEqual(newTree.leaves, [0,1,2,4])
+    }
+    
+    func testInsertLeafAtBeginningSingleDepth() {
+        
+        let leafToInsert = Tree<Int,Int>.leaf(0)
+        let newTree = try! tree.inserting(leafToInsert, at: 0)
+        XCTAssertEqual(newTree.leaves, [0,1,2,3])
+    }
+    
+    func testInsertBranchAtBeginningSingleDepth() {
+        
+        let treeToInsert = Tree.branch(0, [
+            .leaf(-1),
+            .leaf(0)
+        ])
+        
+        let newTree = try! tree.inserting(treeToInsert, at: 0)
+        XCTAssertEqual(newTree.leaves, [-1,0,1,2,3])
+    }
+    
+    func testInsertBranchInMiddleSingleDepth() {
+        
+        let treeToInsert = Tree.branch(0, [
+            .leaf(0),
+            .leaf(0)
+        ])
+        
+        let newTree = try! tree.inserting(treeToInsert, at: 1)
+        XCTAssertEqual(newTree.leaves, [1,0,0,2,3])
+    }
+    
+    func testInsertBranchAtEndSingleDepth() {
+        
+        let treeToInsert = Tree.branch(0, [
+            .leaf(4),
+            .leaf(5)
+        ])
+        
+        let newTree = try! tree.inserting(treeToInsert, at: 3)
+        XCTAssertEqual(newTree.leaves, [1,2,3,4,5])
+    }
+    
+    func testInsertLeafNested() {
+        
+        //         -1
+        //        / | \
+        //      -1 -1  4
+        //         /|\
+        //        1 2(3) insert
+        let tree = Tree.branch(-1, [
+            .leaf(0),
+            .branch(-1, [
+                .leaf(1),
+                .leaf(2)
+            ])
+        ])
+        
+        let newTree = try! tree.inserting(.leaf(3), through: [], at: 2)
+        XCTAssertEqual(newTree.leaves, [0,1,2,3])
+    }
+    
+    func testInsertLeafNestedLessNested() {
+        
+        //         -1
+        //        / | \
+        //      -1 -1  4
+        //         /|\
+        //        1 2(3) insert
+        let tree = Tree.branch(-1, [
+            .leaf(0),
+            .branch(-1, [
+                .leaf(1),
+                .leaf(2)
+            ]),
+            .leaf(3)
+        ])
+        
+        let newTree = try! tree.inserting(.leaf(4), through: [], at: 3)
+        XCTAssertEqual(newTree.leaves, [0,1,2,3,4])
+    }
+    
+    func testInsertBranchReallyNested() {
+        
+        let tree = Tree.branch(-1, [
+            .branch(-1, [
+                .leaf(0),
+                .leaf(1)
+            ]),
+            .branch(-1, [
+                .leaf(2),
+                .branch(-1, [
+                    .leaf(3),
+                    .branch(-1, [
+                        .leaf(4),
+                        
+                        // insert branch here!
+                        
+                        .leaf(10)
+                    ]),
+                    .leaf(11)
+                ]),
+                .leaf(12)
+            ])
+        ])
+        
+        let branchToInsert = Tree.branch(-1, [
+            .leaf(5),
+            .leaf(6),
+            .branch(-1, [
+                .leaf(7),
+                .leaf(8),
+                .leaf(9)
+            ])
+        ])
+        
+        let newTree = try! tree.inserting(branchToInsert, through: [1,1,1], at: 1)
+        XCTAssertEqual(newTree.leaves, [0,1,2,3,4,5,6,7,8,9,10,11,12])
+    }
+    
+    func testMap() {
+        
+        let tree = Tree.branch(1, [
+            .leaf(2),
+            .branch(3, [
+                .leaf(4),
+                .leaf(5)
+            ]),
+            .leaf(6)
+        ])
+        
+        let expected = Tree.branch(2, [
+            .leaf(4),
+            .branch(6, [
+                .leaf(8),
+                .leaf(10)
+            ]),
+            .leaf(12)
+        ])
+        
+        XCTAssert(tree.map { $0 * 2 } == expected)
+    }
+    
+    func testHeightLeafZero() {
+        XCTAssertEqual(Tree<Int,Int>.leaf(0).height, 0)
+    }
+    
+    func testHeightBranchSingleDepthOne() {
+        
+        let branch = Tree.branch(-1, [
+            .leaf(1),
+            .leaf(1)
+        ])
+        
+        XCTAssertEqual(branch.height, 1)
+    }
+    
+    func testHeightNested() {
+        
+        let branch = Tree.branch(-1, [
+            .leaf(1),
+            .branch(1, [
+                .leaf(1),
+                .branch(1, [
+                    .leaf(1),
+                    .leaf(1)
+                ])
+            ])
+        ])
+        
+        XCTAssertEqual(branch.height, 3)
+    }
+    
+    func testPath() {
+        
+        let tree = Tree.branch(1, [
+            .leaf(1),
+            .branch(2, [
+                .leaf(3),
+                .leaf(4)
+            ]),
+            .leaf(5)
+        ])
+        
+        let expected: [[Either<Int,Int>]] = [
+            [.left(1), .right(1)],
+            [.left(1), .left(2), .right(3)],
+            [.left(1), .left(2), .right(4)],
+            [.left(1), .right(5)]
+        ]
+        
+        zip(tree.paths, expected).forEach { path, expected in
+            XCTAssert(path == expected)
+        }
+    }
+    
+    func testPathLeaf() {
+        XCTAssertEqual(Tree<Int,Int>.leaf(1).paths.count, 1)
+        XCTAssert(Tree<Int,Int>.leaf(1).paths[0][0] == .right(1))
+    }
+    
+    func testTreeZip() {
+        
+        let a = Tree.branch(1, [
+            .leaf(2),
+            .leaf(3),
+            .branch(4, [
+                .leaf(5),
+                .leaf(6)
+                ])
+            ])
+        
+        let b = Tree.branch(0, [
+            .leaf(1),
+            .leaf(2),
+            .branch(3, [
+                .leaf(4),
+                .leaf(5)
+                ])
+            ])
+        
+        let expected = Tree.branch(0, [
+            .leaf(2),
+            .leaf(6),
+            .branch(12, [
+                .leaf(20),
+                .leaf(30)
+                ])
+            ])
+        
+        let result = zip(a,b,*)
+        XCTAssert(result == expected)
+    }
+    
+    func testInitWithValueAndEmptyArray() {
+        let tree = Tree(1, [])
+        let expected = Tree.branch(1, [.leaf(1)])
+        XCTAssert(tree == expected)
+    }
+}

--- a/CollectionsTests/ZipperTests.swift
+++ b/CollectionsTests/ZipperTests.swift
@@ -9,270 +9,270 @@
 import XCTest
 import Collections
 
-class ZipperTests: XCTestCase {
-
-    func testInit() {
-        let t = Tree.leaf(0)
-        _ = Zipper(t)
-    }
-    
-    func testmoveToIndexLeafError() {
-        let z = Zipper(.leaf(0))
-        XCTAssertThrowsError(try z.move(to: 0))
-    }
-    
-    func testmoveToIndexZeroNoError() {
-        
-        let t = Tree.branch(-1, [
-            .leaf(1),
-            .leaf(2),
-            .leaf(3)
-        ])
-        
-        let z = Zipper(t)
-        
-        let result = try! z.move(to: 0)
-        XCTAssert(result.tree == Tree.leaf(1))
-        XCTAssertEqual(result.breadcrumbs.count, 1)
-        XCTAssertEqual(result.breadcrumbs[0].value, -1)
-        XCTAssert(result.breadcrumbs[0].trees.0 == [])
-        XCTAssert(result.breadcrumbs[0].trees.1 == [.leaf(2), .leaf(3)])
-    }
-    
-    func testmoveToIndexMiddleNoError() {
-        
-        let t = Tree.branch(-1, [
-            .leaf(1),
-            .leaf(2),
-            .leaf(3)
-        ])
-        
-        let z = Zipper(t)
-        
-        let result = try! z.move(to: 1)
-        XCTAssert(result.tree == Tree.leaf(2))
-        XCTAssertEqual(result.breadcrumbs.count, 1)
-    }
-    
-    func testToIndexEndNoError() {
-        
-        let t = Tree.branch(-1, [
-            .leaf(1),
-            .leaf(2),
-            .leaf(3)
-        ])
-    
-        let z = Zipper(t)
-        
-        let result = try! z.move(to: 2)
-        XCTAssert(result.tree == Tree.leaf(3))
-        XCTAssertEqual(result.breadcrumbs.count, 1)
-    }
-    
-    func testToIndexToFarError() {
-        
-        let t = Tree.branch(-1, [
-            .leaf(1),
-            .leaf(2),
-            .leaf(3)
-        ])
-        
-        let z = Zipper(t)
-        
-        XCTAssertThrowsError(try z.move(to: 3))
-    }
-    
-    func testTop() {
-        
-        let t = Tree.branch(-1, [
-            .leaf(1),
-            .leaf(2),
-            .leaf(3)
-        ])
-        
-        let z = Zipper(t)
-        
-        XCTAssert(z.top.tree == z.tree)
-    }
-    
-    func testMoveToIndexNested() {
-        
-        let t = Tree.branch(-1, [
-            .leaf(1),
-            .branch(-1, [
-                .leaf(2),
-                .leaf(3),
-                .leaf(4)
-            ]),
-            .leaf(5)
-        ])
-        
-        let z = Zipper(t)
-        let branch = try! z.move(to: 1)
-        
-        XCTAssertEqual(branch.tree.leaves, [2,3,4])
-    }
-    
-    func testUpFromNested() {
-        
-        let t = Tree.branch(-1, [
-            .leaf(1),
-            .branch(-1, [
-                .leaf(2),
-                .leaf(3),
-                .leaf(4)
-            ]),
-            .leaf(5)
-        ])
-        
-        let z = Zipper(t)
-        let top = try! z.move(to: 1).up!
-        
-        XCTAssertEqual(top.tree.leaves, z.tree.leaves)
-    }
-    
-    func testUp() {
-        
-        let t = Tree.branch(-1, [
-            .leaf(1),
-            .branch(-1, [
-                .leaf(2),
-                .leaf(3),
-                .leaf(4)
-            ]),
-            .leaf(5)
-        ])
-        
-        let z = Zipper(t)
-        let three = try! z.move(to: 1).move(to: 1)
-        let middle = three.up!
-        let top = middle.up!
-        
-        XCTAssertEqual(middle.tree.leaves, [2,3,4])
-        XCTAssertEqual(top.tree.leaves, z.tree.leaves)
-        XCTAssert(three.up!.up!.tree == z.tree)
-    }
-    
-    func testUpdate() {
-        
-        let t = Tree.branch(-1, [
-            .leaf(1),
-            .branch(-1, [
-                .leaf(2),
-                .leaf(3),
-                .leaf(4)
-            ]),
-            .leaf(5)
-        ])
-        
-        let z = Zipper(t)
-        let updated = try! z.move(to: 1).move(to: 1).update { $0 * 2 }.top
-        XCTAssertEqual(updated.tree.leaves, [1,2,6,4,5])
-    }
-    
-    func testUpdateValue() {
-        
-        let t = Tree.branch(-1, [
-            .leaf(1),
-            .branch(-1, [
-                .leaf(2),
-                .leaf(3),
-                .leaf(4)
-            ]),
-            .leaf(5)
-        ])
-        
-        let z = Zipper(t)
-        let updated = try! z.move(to: 2).update(value: 0)
-        XCTAssertEqual(updated.tree.value, 0)
-    }
-    
-    func testMoveThroughPathEmpty() {
-        
-        let t = Tree.branch(-1, [
-            .leaf(1),
-            .branch(-1, [
-                .leaf(2),
-                .leaf(3),
-                .leaf(4)
-            ]),
-            .leaf(5)
-        ])
-        
-        let z = Zipper(t)
-        let three = try! z.move(through: [])
-        XCTAssert(z.tree == three.tree)
-    }
-    
-    func testMoveThroughPathNotEmpty() {
-        
-        let t = Tree.branch(-1, [
-            .leaf(1),
-            .branch(-1, [
-                .leaf(2),
-                .leaf(3),
-                .leaf(4)
-            ]),
-            .leaf(5)
-        ])
-        
-        
-        let z = Zipper(t)
-        let three = try! z.move(through: [1,1])
-        XCTAssert(three.tree == .leaf(3))
-    }
-    
-    func testMoveThroughPathBadPathError() {
-        
-        let t = Tree.branch(-1, [
-            .leaf(1),
-            .branch(-1, [
-                .leaf(2),
-                .leaf(3),
-                .leaf(4)
-            ]),
-            .leaf(5)
-        ])
-        
-        let z = Zipper(t)
-        XCTAssertThrowsError(try z.move(through: [2,3]))
-    }
-    
-    func testChildren() {
-        
-        let t = Tree.branch(-1, [
-            .leaf(1),
-            .branch(-1, [
-                .leaf(2),
-                .leaf(3),
-                .leaf(4)
-            ]),
-            .leaf(5)
-        ])
-        
-        let z = Zipper(t)
-        let zChildren = z.children
-        XCTAssertEqual(zChildren.count, 3)
-        
-        let internalBranch = try! z.move(to: 1)
-        let internalBranchChildren = internalBranch.children
-        XCTAssertEqual(internalBranchChildren.count, 3)
-    }
-    
-    func testSiblings() {
-        
-        let t = Tree.branch(-1, [
-            .leaf(1),
-            .branch(-1, [
-                .leaf(2),
-                .leaf(3),
-                .leaf(4)
-            ]),
-            .leaf(5)
-        ])
-        
-        let z = Zipper(t)
-        
-        XCTAssertEqual(z.siblings.count, 0)
-    }
-}
+//class ZipperTests: XCTestCase {
+//
+//    func testInit() {
+//        let t = Tree.leaf(0)
+//        _ = Zipper(t)
+//    }
+//    
+//    func testmoveToIndexLeafError() {
+//        let z = Zipper(.leaf(0))
+//        XCTAssertThrowsError(try z.move(to: 0))
+//    }
+//    
+//    func testmoveToIndexZeroNoError() {
+//        
+//        let t = Tree.branch(-1, [
+//            .leaf(1),
+//            .leaf(2),
+//            .leaf(3)
+//        ])
+//        
+//        let z = Zipper(t)
+//        
+//        let result = try! z.move(to: 0)
+//        XCTAssert(result.tree == Tree.leaf(1))
+//        XCTAssertEqual(result.breadcrumbs.count, 1)
+//        XCTAssertEqual(result.breadcrumbs[0].value, -1)
+//        XCTAssert(result.breadcrumbs[0].trees.0 == [])
+//        XCTAssert(result.breadcrumbs[0].trees.1 == [.leaf(2), .leaf(3)])
+//    }
+//    
+//    func testmoveToIndexMiddleNoError() {
+//        
+//        let t = Tree.branch(-1, [
+//            .leaf(1),
+//            .leaf(2),
+//            .leaf(3)
+//        ])
+//        
+//        let z = Zipper(t)
+//        
+//        let result = try! z.move(to: 1)
+//        XCTAssert(result.tree == Tree.leaf(2))
+//        XCTAssertEqual(result.breadcrumbs.count, 1)
+//    }
+//    
+//    func testToIndexEndNoError() {
+//        
+//        let t = Tree.branch(-1, [
+//            .leaf(1),
+//            .leaf(2),
+//            .leaf(3)
+//        ])
+//    
+//        let z = Zipper(t)
+//        
+//        let result = try! z.move(to: 2)
+//        XCTAssert(result.tree == Tree.leaf(3))
+//        XCTAssertEqual(result.breadcrumbs.count, 1)
+//    }
+//    
+//    func testToIndexToFarError() {
+//        
+//        let t = Tree.branch(-1, [
+//            .leaf(1),
+//            .leaf(2),
+//            .leaf(3)
+//        ])
+//        
+//        let z = Zipper(t)
+//        
+//        XCTAssertThrowsError(try z.move(to: 3))
+//    }
+//    
+//    func testTop() {
+//        
+//        let t = Tree.branch(-1, [
+//            .leaf(1),
+//            .leaf(2),
+//            .leaf(3)
+//        ])
+//        
+//        let z = Zipper(t)
+//        
+//        XCTAssert(z.top.tree == z.tree)
+//    }
+//    
+//    func testMoveToIndexNested() {
+//        
+//        let t = Tree.branch(-1, [
+//            .leaf(1),
+//            .branch(-1, [
+//                .leaf(2),
+//                .leaf(3),
+//                .leaf(4)
+//            ]),
+//            .leaf(5)
+//        ])
+//        
+//        let z = Zipper(t)
+//        let branch = try! z.move(to: 1)
+//        
+//        XCTAssertEqual(branch.tree.leaves, [2,3,4])
+//    }
+//    
+//    func testUpFromNested() {
+//        
+//        let t = Tree.branch(-1, [
+//            .leaf(1),
+//            .branch(-1, [
+//                .leaf(2),
+//                .leaf(3),
+//                .leaf(4)
+//            ]),
+//            .leaf(5)
+//        ])
+//        
+//        let z = Zipper(t)
+//        let top = try! z.move(to: 1).up!
+//        
+//        XCTAssertEqual(top.tree.leaves, z.tree.leaves)
+//    }
+//    
+//    func testUp() {
+//        
+//        let t = Tree.branch(-1, [
+//            .leaf(1),
+//            .branch(-1, [
+//                .leaf(2),
+//                .leaf(3),
+//                .leaf(4)
+//            ]),
+//            .leaf(5)
+//        ])
+//        
+//        let z = Zipper(t)
+//        let three = try! z.move(to: 1).move(to: 1)
+//        let middle = three.up!
+//        let top = middle.up!
+//        
+//        XCTAssertEqual(middle.tree.leaves, [2,3,4])
+//        XCTAssertEqual(top.tree.leaves, z.tree.leaves)
+//        XCTAssert(three.up!.up!.tree == z.tree)
+//    }
+//    
+//    func testUpdate() {
+//        
+//        let t = Tree.branch(-1, [
+//            .leaf(1),
+//            .branch(-1, [
+//                .leaf(2),
+//                .leaf(3),
+//                .leaf(4)
+//            ]),
+//            .leaf(5)
+//        ])
+//        
+//        let z = Zipper(t)
+//        let updated = try! z.move(to: 1).move(to: 1).update { $0 * 2 }.top
+//        XCTAssertEqual(updated.tree.leaves, [1,2,6,4,5])
+//    }
+//    
+//    func testUpdateValue() {
+//        
+//        let t = Tree.branch(-1, [
+//            .leaf(1),
+//            .branch(-1, [
+//                .leaf(2),
+//                .leaf(3),
+//                .leaf(4)
+//            ]),
+//            .leaf(5)
+//        ])
+//        
+//        let z = Zipper(t)
+//        let updated = try! z.move(to: 2).update(value: 0)
+//        XCTAssertEqual(updated.tree.value, 0)
+//    }
+//    
+//    func testMoveThroughPathEmpty() {
+//        
+//        let t = Tree.branch(-1, [
+//            .leaf(1),
+//            .branch(-1, [
+//                .leaf(2),
+//                .leaf(3),
+//                .leaf(4)
+//            ]),
+//            .leaf(5)
+//        ])
+//        
+//        let z = Zipper(t)
+//        let three = try! z.move(through: [])
+//        XCTAssert(z.tree == three.tree)
+//    }
+//    
+//    func testMoveThroughPathNotEmpty() {
+//        
+//        let t = Tree.branch(-1, [
+//            .leaf(1),
+//            .branch(-1, [
+//                .leaf(2),
+//                .leaf(3),
+//                .leaf(4)
+//            ]),
+//            .leaf(5)
+//        ])
+//        
+//        
+//        let z = Zipper(t)
+//        let three = try! z.move(through: [1,1])
+//        XCTAssert(three.tree == .leaf(3))
+//    }
+//    
+//    func testMoveThroughPathBadPathError() {
+//        
+//        let t = Tree.branch(-1, [
+//            .leaf(1),
+//            .branch(-1, [
+//                .leaf(2),
+//                .leaf(3),
+//                .leaf(4)
+//            ]),
+//            .leaf(5)
+//        ])
+//        
+//        let z = Zipper(t)
+//        XCTAssertThrowsError(try z.move(through: [2,3]))
+//    }
+//    
+//    func testChildren() {
+//        
+//        let t = Tree.branch(-1, [
+//            .leaf(1),
+//            .branch(-1, [
+//                .leaf(2),
+//                .leaf(3),
+//                .leaf(4)
+//            ]),
+//            .leaf(5)
+//        ])
+//        
+//        let z = Zipper(t)
+//        let zChildren = z.children
+//        XCTAssertEqual(zChildren.count, 3)
+//        
+//        let internalBranch = try! z.move(to: 1)
+//        let internalBranchChildren = internalBranch.children
+//        XCTAssertEqual(internalBranchChildren.count, 3)
+//    }
+//    
+//    func testSiblings() {
+//        
+//        let t = Tree.branch(-1, [
+//            .leaf(1),
+//            .branch(-1, [
+//                .leaf(2),
+//                .leaf(3),
+//                .leaf(4)
+//            ]),
+//            .leaf(5)
+//        ])
+//        
+//        let z = Zipper(t)
+//        
+//        XCTAssertEqual(z.siblings.count, 0)
+//    }
+//}


### PR DESCRIPTION
Make `Tree` parameterized over two different types: one for `.leaf` cases, and another for `.branch` cases.