### PR TITLE
Revert "Make Stack.pop() result discardable"

### DIFF
--- a/Collections/Stack.swift
+++ b/Collections/Stack.swift
@@ -60,7 +60,7 @@ public struct Stack <T> {
     }
 
     /// - returns: Item from top of `Stack` if there are any. Otherwise, `nil`.
-    @discardableResult public mutating func pop() -> T? {
+    public mutating func pop() -> T? {
         return items.popLast()
     }
 


### PR DESCRIPTION
This reverts commit 778aa685e5c79370414df640dd376a5bcc44ca72, which I accidentally pushed to master.