### PR TITLE
Switch macOS perf tests to debug instead of release

### DIFF
--- a/Collections.xcodeproj/xcshareddata/xcschemes/Collections macOS (Performance).xcscheme
+++ b/Collections.xcodeproj/xcshareddata/xcschemes/Collections macOS (Performance).xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">


### PR DESCRIPTION
committed this by accident; the iOS performance tests already run under debug