### PR TITLE
Use Collections.KeyPath explicitly in tests

### DIFF
--- a/CollectionsTests/KeyPathTests.swift
+++ b/CollectionsTests/KeyPathTests.swift
@@ -12,17 +12,17 @@ import Collections
 class KeyPathTests: XCTestCase {
 
     func testInitArray() {
-        let keyPath = KeyPath(["1", "2", "ok"])
+        let keyPath = Collections.KeyPath(["1", "2", "ok"])
         XCTAssertEqual(keyPath.count, 3)
     }
 
     func testInitArrayLiteral() {
-        let keyPath: KeyPath = ["1", "2", "ok"]
+        let keyPath: Collections.KeyPath = ["1", "2", "ok"]
         XCTAssertEqual(keyPath.count, 3)
     }
 
     func testInitStringLiteral() {
-        let keyPath: KeyPath = "a.b.2.ok.g"
+        let keyPath: Collections.KeyPath = "a.b.2.ok.g"
         XCTAssertEqual(keyPath.count, 5)
     }
 


### PR DESCRIPTION
This is necessary to avoid a compilation failure with the most recent Swift 4 compiler.