### PR TITLE
Replace throws/fatalErrors with asserts in Tree and Array

### DIFF
--- a/Collections/ReplaceElements.swift
+++ b/Collections/ReplaceElements.swift
@@ -13,11 +13,10 @@ extension Array {
 
     /// Replace element at given `index` with the given `element`.
     public mutating func replaceElement(at index: Int, with element: Element)
-        throws
     {
 
         guard index >= startIndex && index < endIndex else {
-            throw ArrayError.removalError
+            assert(false)
         }
 
         remove(at: index)
@@ -25,9 +24,9 @@ extension Array {
     }
 
     /// Immutable version of `replaceElement(at:with:)`
-    public func replacingElement(at index: Int, with element: Element) throws -> Array {
+    public func replacingElement(at index: Int, with element: Element) -> Array {
         var copy = self
-        try copy.replaceElement(at: index, with: element)
+        copy.replaceElement(at: index, with: element)
         return copy
     }
 

--- a/Collections/Tree.swift
+++ b/Collections/Tree.swift
@@ -207,7 +207,7 @@ public enum Tree <Branch,Leaf> {
             case .leaf(let leaf):
 
                 guard let value = newValues.first else {
-                    fatalError("Incompatible collection for leaves")
+                    assert(false, "Incompatible collection for leaves")
                 }
 
                 return .leaf(transform(leaf,value))
@@ -290,7 +290,7 @@ public func zip <T,U,V> (_ a: Tree<T,T>, _ b: Tree<U,U>, _ f: (T, U) -> V) -> Tr
     case (.branch(let a, let aTrees), .branch(let b, let bTrees)):
         return .branch(f(a,b), zip(aTrees,bTrees).map { a,b in zip(a,b,f) })
     default:
-        fatalError("Incompatible trees")
+        assert(false, "Incompatible trees")
     }
 }
 


### PR DESCRIPTION
Fixes #159

This is totally speculative, I just wanted to see what would happen.
My guess is that the changes to Array are not desired.
I'm also guessing some of these assert(false...) can be directly replaced with boolean conditions.